### PR TITLE
fetch_by_indexのキャッシュをversioningする

### DIFF
--- a/lib/second_level_cache/active_record/fetch_by_index.rb
+++ b/lib/second_level_cache/active_record/fetch_by_index.rb
@@ -25,7 +25,7 @@ module SecondLevelCache
       end
 
       def cache_index_key(kv)
-        "#{SecondLevelCache.cache_key_prefix}/#{self.name.downcase}/fbi/#{kv.keys.sort.join(':')}/#{kv.values_at(*kv.keys.sort).join(':')}"
+        "#{SecondLevelCache.cache_key_prefix}/#{self.name.downcase}/fbi/#{kv.keys.sort.join(':')}/#{kv.values_at(*kv.keys.sort).join(':')}/#{self.cache_version}"
       end
     end
   end

--- a/test/active_record/fetch_by_index_test.rb
+++ b/test/active_record/fetch_by_index_test.rb
@@ -56,7 +56,7 @@ class ActiveRecord::FetchByIndexTest < Test::Unit::TestCase
   end
 
   def test_cache_index_key
-    assert_equal Review.cache_index_key(user_id: @user.id), "slc/review/fbi/user_id/#{@user.id}"
-    assert_equal Review.cache_index_key(user_id: @user.id, book_id: 1), "slc/review/fbi/book_id:user_id/1:#{@user.id}"
+    assert_equal Review.cache_index_key(user_id: @user.id), "slc/review/fbi/user_id/#{@user.id}/1"
+    assert_equal Review.cache_index_key(user_id: @user.id, book_id: 1), "slc/review/fbi/book_id:user_id/1:#{@user.id}/1"
   end
 end


### PR DESCRIPTION
primary keyの配列を格納しているキャッシュもバージョニングするようにし不整合が起きた場合でもバージョンを上げる事でキャッシュを切り替えられるようにします。
