### PR TITLE
インデックスのキャッシュに有効期限を設定する

### DIFF
--- a/lib/second_level_cache/active_record/fetch_by_index.rb
+++ b/lib/second_level_cache/active_record/fetch_by_index.rb
@@ -7,7 +7,7 @@ module SecondLevelCache
         ids = SecondLevelCache.cache_store.read(cache_index_key(argv))
         unless ids
           ids = self.where(**argv).pluck(primary_key)
-          SecondLevelCache.cache_store.write(cache_index_key(argv), ids)
+          SecondLevelCache.cache_store.write(cache_index_key(argv), ids, expires_in: self.second_level_cache_options[:expires_in])
         end
         return [] unless ids.present?
 


### PR DESCRIPTION
インデックスのキャッシュに有効期限を設定せず消えない状態になっていると運用上不都合が発生するため有効期限を設定します。
モデルのキャッシュと同じ有効期限のため、両方同時にキャッシュ切れになってしまいますがそれは許容しています。
