### PR TITLE
[WIP]method_cache

### DIFF
--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -135,23 +135,6 @@ module SecondLevelCache
     end
 
     alias update_slc_index_cache delete_slc_index_cache
-
-    def delete_method_cache
-      if self.class.second_level_cache_enabled? && self.class.second_level_cache_options.key?(:method_cache)
-        self.class.second_level_cache_options[:method_cache].each do |target|
-          key_additional = []
-          if target[:opt].key?(:with_attr)
-            target[:opt][:with_attr].each do |attr|
-              key_additional << self.send(attr)
-            end
-          end
-
-          self.class.method_cache_keys(target[:symbol], *key_additional).each { |key| SecondLevelCache.cache_store.delete(key) }
-        end
-      end
-    end
-
-    alias update_method_cache delete_method_cache
   end
 end
 

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -135,6 +135,23 @@ module SecondLevelCache
     end
 
     alias update_slc_index_cache delete_slc_index_cache
+
+    def delete_method_cache
+      if self.class.second_level_cache_enabled? && self.class.second_level_cache_options.key?(:method_cache)
+        self.class.second_level_cache_options[:method_cache].each do |target|
+          key_additional = []
+          if target[:opt].key?(:with_attr)
+            target[:opt][:with_attr].each do |attr|
+              key_additional << self.send(attr)
+            end
+          end
+
+          self.class.method_cache_keys(target[:symbol], *key_additional).each { |key| SecondLevelCache.cache_store.delete(key) }
+        end
+      end
+    end
+
+    alias update_method_cache delete_method_cache
   end
 end
 

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -2,7 +2,6 @@
 require 'active_support/all'
 require 'second_level_cache/config'
 require 'second_level_cache/record_marshal'
-require 'second_level_cache/method_cache'
 
 module SecondLevelCache
   def self.configure

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -9,7 +9,7 @@ module SecondLevelCache
   end
 
   class << self
-    delegate :logger, :cache_store, :cache_key_prefix, :to => Config
+    delegate :logger, :cache_store, :cache_key_prefix, :number_of_distributed_keys, :to => Config
   end
 
   module Mixin

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -2,6 +2,7 @@
 require 'active_support/all'
 require 'second_level_cache/config'
 require 'second_level_cache/record_marshal'
+require 'second_level_cache/method_cache'
 
 module SecondLevelCache
   def self.configure

--- a/lib/second_level_cache/active_record.rb
+++ b/lib/second_level_cache/active_record.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 require 'second_level_cache/active_record/base'
+require 'second_level_cache/method_cache'
 require 'second_level_cache/active_record/fetch_by_uniq_key'
 require 'second_level_cache/active_record/fetch_by_index'
 require 'second_level_cache/active_record/finder_methods'
@@ -8,6 +9,7 @@ require 'second_level_cache/active_record/belongs_to_association'
 require 'second_level_cache/active_record/has_one_association'
 
 ActiveRecord::Base.send(:include, SecondLevelCache::Mixin)
+ActiveRecord::Base.send(:include, SecondLevelCache::MethodCache::Mixin)
 ActiveRecord::Base.send(:include, SecondLevelCache::ActiveRecord::Base)
 ActiveRecord::Base.send(:extend, SecondLevelCache::ActiveRecord::FetchByUniqKey)
 ActiveRecord::Base.send(:extend, SecondLevelCache::ActiveRecord::FetchByIndex)

--- a/lib/second_level_cache/active_record/base.rb
+++ b/lib/second_level_cache/active_record/base.rb
@@ -15,6 +15,9 @@ module SecondLevelCache
         after_commit :delete_method_cache, :on => :destroy
         after_commit :update_method_cache, :on => :update
 
+        after_save :delete_method_cache_after_save, :on => :destroy
+        after_save :update_method_cache_after_save, :on => :update
+
         class << self
           alias_method_chain :update_counters, :cache
         end

--- a/lib/second_level_cache/active_record/base.rb
+++ b/lib/second_level_cache/active_record/base.rb
@@ -8,8 +8,12 @@ module SecondLevelCache
         after_commit :expire_second_level_cache, :on => :destroy
         after_commit :update_second_level_cache, :on => :update
         after_commit :write_second_level_cache, :on => :create
+
         after_commit :delete_slc_index_cache, :on => :destroy
         after_commit :update_slc_index_cache, :on => :create
+
+        after_commit :delete_method_cache, :on => :destroy
+        after_commit :update_method_cache, :on => :update
 
         class << self
           alias_method_chain :update_counters, :cache

--- a/lib/second_level_cache/config.rb
+++ b/lib/second_level_cache/config.rb
@@ -3,7 +3,7 @@ module SecondLevelCache
   module Config
     extend self
 
-    attr_accessor :cache_store, :logger, :cache_key_prefix
+    attr_accessor :cache_store, :logger, :cache_key_prefix, :number_of_distributed_keys
 
     def cache_store
       @cache_store ||= Rails.cache if defined?(Rails)
@@ -17,6 +17,10 @@ module SecondLevelCache
 
     def cache_key_prefix
       @cache_key_prefix ||= 'slc'
+    end
+
+    def number_of_distributed_keys
+      @number_of_distributed_keys ||= 10
     end
   end
 end

--- a/lib/second_level_cache/method_cache.rb
+++ b/lib/second_level_cache/method_cache.rb
@@ -131,14 +131,19 @@ module SecondLevelCache
               end
             end
 
-            singleton_class.send(:define_method, symbol) do |*args|
-              SecondLevelCache::MethodCache.cache_return_value_with_class_method(self, symbol, args, opt, original_method)
+            unless opt.fetch(:expire_only, false)
+              singleton_class.send(:define_method, symbol) do |*args|
+                SecondLevelCache::MethodCache.cache_return_value_with_class_method(self, symbol, args, opt, original_method)
+              end
             end
             @second_level_cache_options[:method_cache] << {symbol: symbol, opt: opt}
           rescue NameError => e
             original_method = instance_method(symbol)
-            define_method(symbol) do |*args|
-              SecondLevelCache::MethodCache.cache_return_value_with_instance_method(self, symbol, args, opt, original_method)
+
+            unless opt.fetch(:expire_only, false)
+              define_method(symbol) do |*args|
+                SecondLevelCache::MethodCache.cache_return_value_with_instance_method(self, symbol, args, opt, original_method)
+              end
             end
             @second_level_cache_options[:method_cache] << {symbol: symbol, opt: opt}
           end

--- a/lib/second_level_cache/method_cache.rb
+++ b/lib/second_level_cache/method_cache.rb
@@ -39,11 +39,6 @@ module SecondLevelCache
           raise ArgumentError unless self.second_level_cache_enabled?
           begin
             original_method = method(symbol)
-            if original_method.arity > 0
-              args = [1]
-            else
-              args = []
-            end
             singleton_class.send(:define_method, symbol) do |*args|
               SecondLevelCache::MethodCache.cache_return_value(self, symbol, args, original_method)
             end

--- a/lib/second_level_cache/method_cache.rb
+++ b/lib/second_level_cache/method_cache.rb
@@ -1,0 +1,64 @@
+module SecondLevelCache
+  class MethodCache
+    def self.cache_return_value(klass, symbol, args, original_method)
+      value = SecondLevelCache.cache_store.read(klass.method_cache_key(symbol, *args))
+      if value.nil?
+        res = if args.size > 0
+                original_method.call(args)
+              else
+                original_method.call
+              end
+        SecondLevelCache.cache_store.write(klass.method_cache_key(symbol, *args), res)
+      else
+        value
+      end
+    end
+
+    def self.cache_return_value_with_instance_method(instance, symbol, args, opt, original_method)
+      key_additional = []
+      if opt.key?(:with_attr)
+        opt[:with_attr].each do |attr|
+          key_additional << instance.send(attr)
+        end
+      end
+
+      value = SecondLevelCache.cache_store.read(instance.class.method_cache_key(symbol, *key_additional))
+      if value.nil?
+        res = original_method.bind(instance).call
+        SecondLevelCache.cache_store.write(instance.class.method_cache_key(symbol, *key_additional), res)
+      else
+        value
+      end
+    end
+
+    module Mixin
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def method_cache(symbol, **opt)
+          raise ArgumentError unless self.second_level_cache_enabled?
+          begin
+            original_method = method(symbol)
+            if original_method.arity > 0
+              args = [1]
+            else
+              args = []
+            end
+            singleton_class.send(:define_method, symbol) do |*args|
+              SecondLevelCache::MethodCache.cache_return_value(self, symbol, args, original_method)
+            end
+          rescue NameError
+            original_method = instance_method(symbol)
+            define_method(symbol) do |*args|
+              SecondLevelCache::MethodCache.cache_return_value_with_instance_method(self, symbol, args, opt, original_method)
+            end
+          end
+        end
+
+        def method_cache_key(*keys)
+          "#{SecondLevelCache.cache_key_prefix}/#{self.name.downcase}/mc/#{self.cache_version}/#{keys.join('/')}"
+        end
+      end
+    end
+  end
+end

--- a/lib/second_level_cache/method_cache.rb
+++ b/lib/second_level_cache/method_cache.rb
@@ -131,7 +131,7 @@ module SecondLevelCache
               end
             end
 
-            unless opt.fetch(:expire_only, false)
+            unless opt.fetch(:invalidate_only, false)
               singleton_class.send(:define_method, symbol) do |*args|
                 SecondLevelCache::MethodCache.cache_return_value_with_class_method(self, symbol, args, opt, original_method)
               end
@@ -140,7 +140,7 @@ module SecondLevelCache
           rescue NameError => e
             original_method = instance_method(symbol)
 
-            unless opt.fetch(:expire_only, false)
+            unless opt.fetch(:invalidate_only, false)
               define_method(symbol) do |*args|
                 SecondLevelCache::MethodCache.cache_return_value_with_instance_method(self, symbol, args, opt, original_method)
               end

--- a/lib/second_level_cache/method_cache.rb
+++ b/lib/second_level_cache/method_cache.rb
@@ -1,52 +1,52 @@
 module SecondLevelCache
   class MethodCache
-    def self.cache_return_value_with_class_method(klass, symbol, args, opt, original_method)
-      cache_keys = klass.method_cache_keys(symbol, *args, **opt)
-      value = fetch_cache(cache_keys)
-      return value.first if value.present? && opt.key?(:negative) && opt[:negative]
-      return value if value.present?
-
-      res = if args.size > 0
-              original_method.call(*args)
-            else
-              original_method.call
-            end
-      unless opt.key?(:expires_in)
-        opt[:expires_in] = klass.second_level_cache_options[:expires_in]
-      end
-
-      cache_keys = klass.method_cache_keys(symbol, *args, **opt)
-      write_cache(cache_keys, res, opt)
-      res
-    end
-
-    def self.cache_return_value_with_instance_method(instance, symbol, args, opt, original_method)
-      key_additional = []
-      if opt.key?(:with_attr)
-        opt[:with_attr].each do |attr|
-          key_additional << instance.send(attr)
-        end
-      end
-
-      value = fetch_cache(instance.class.method_cache_keys(symbol, *key_additional, **opt))
-      return value.first if value.present? && opt.key?(:negative) && opt[:negative]
-      return value if value.present?
-
-      res = if args.size > 0
-              original_method.bind(instance).call(*args)
-            else
-              original_method.bind(instance).call
-            end
-      unless opt.key?(:expires_in)
-        opt[:expires_in] = instance.class.second_level_cache_options[:expires]
-      end
-
-      cache_keys = instance.class.method_cache_keys(symbol, *key_additional, **opt)
-      write_cache(cache_keys, res, opt)
-      res
-    end
-
     class << self
+      def cache_return_value_with_class_method(klass, symbol, args, opt, original_method)
+        keys = [symbol, *args]
+        cache_keys = klass.method_cache_keys(*keys, **opt)
+        value = fetch_cache(cache_keys)
+        return value.first if value.present? && opt.key?(:negative) && opt[:negative]
+        return value if value.present?
+
+        res = if args.size > 0
+                original_method.call(*args)
+              else
+                original_method.call
+              end
+        unless opt.key?(:expires_in)
+          opt[:expires_in] = klass.second_level_cache_options[:expires_in]
+        end
+
+        write_cache(cache_keys, res, opt)
+        res
+      end
+
+      def cache_return_value_with_instance_method(instance, symbol, args, opt, original_method)
+        key_additional = []
+        if opt.key?(:with_attr)
+          opt[:with_attr].each do |attr|
+            key_additional << instance.send(attr)
+          end
+        end
+
+        value = fetch_cache(instance.class.method_cache_keys(symbol, *key_additional, **opt))
+        return value.first if value.present? && opt.key?(:negative) && opt[:negative]
+        return value if value.present?
+
+        res = if args.size > 0
+                original_method.bind(instance).call(*args)
+              else
+                original_method.bind(instance).call
+              end
+        unless opt.key?(:expires_in)
+          opt[:expires_in] = instance.class.second_level_cache_options[:expires]
+        end
+
+        cache_keys = instance.class.method_cache_keys(symbol, *key_additional, **opt)
+        write_cache(cache_keys, res, opt)
+        res
+      end
+
       private
       def fetch_cache(keys)
         keys.shuffle.each do |key|
@@ -71,6 +71,24 @@ module SecondLevelCache
     module Mixin
       extend ActiveSupport::Concern
 
+      def delete_method_cache
+        return unless self.class.second_level_cache_enabled?
+        return unless self.class.second_level_cache_options.key?(:method_cache)
+
+        self.class.second_level_cache_options[:method_cache].each do |target|
+          key_additional = []
+          if target[:opt].key?(:with_attr)
+            target[:opt][:with_attr].each do |attr|
+              key_additional << self.send(attr)
+            end
+          end
+
+          keys = [target[:symbol], *key_additional]
+          self.class.method_cache_keys(*keys, **target[:opt]).each { |key| SecondLevelCache.cache_store.delete(key) }
+        end
+      end
+      alias update_method_cache delete_method_cache
+
       module ClassMethods
         def method_cache(symbol, **opt)
           raise ArgumentError unless self.second_level_cache_enabled?
@@ -79,15 +97,15 @@ module SecondLevelCache
           begin
             original_method = method(symbol)
             if original_method.arity > 0
-              raise ArgumentError unless opt.key?(:with_attr)
-              raise ArgumentError if opt[:with_attr].size != original_method.arity
+              raise ArgumentError if !opt.key?(:composer) && !opt.key?(:with_attr)
+              raise ArgumentError if opt.key?(:with_attr) && opt[:with_attr].size != original_method.arity
             end
 
             singleton_class.send(:define_method, symbol) do |*args|
               SecondLevelCache::MethodCache.cache_return_value_with_class_method(self, symbol, args, opt, original_method)
             end
             @second_level_cache_options[:method_cache] << {symbol: symbol, opt: opt}
-          rescue NameError
+          rescue NameError => e
             original_method = instance_method(symbol)
             define_method(symbol) do |*args|
               SecondLevelCache::MethodCache.cache_return_value_with_instance_method(self, symbol, args, opt, original_method)
@@ -97,14 +115,14 @@ module SecondLevelCache
         end
 
         def method_cache_keys(*keys, **opt)
-          if opt.key?(:distributed) && opt[:distributed]
-            opt.delete(:distributed)
+          if opt.key?(:distributed) && opt.delete(:distributed)
             SecondLevelCache.number_of_distributed_keys.times.map { |i| method_cache_keys("distributed", i, keys, **opt) }.flatten
           else
             key_seed = []
             key_seed << opt[:prefix] if opt.key?(:prefix)
             key_seed << keys
-            ["#{SecondLevelCache.cache_key_prefix}/#{self.name.downcase}/mc/#{self.cache_version}/#{key_seed.flatten.join('/')}"]
+            key_seed << opt[:composer].call if opt.key?(:composer)
+            ["#{SecondLevelCache.cache_key_prefix}/#{self.name.downcase}/mc/#{self.cache_version}/#{key_seed.flatten.compact.join('/')}"]
           end
         end
       end

--- a/lib/second_level_cache/method_cache.rb
+++ b/lib/second_level_cache/method_cache.rb
@@ -97,8 +97,10 @@ module SecondLevelCache
           begin
             original_method = method(symbol)
             if original_method.arity > 0
-              raise ArgumentError if !opt.key?(:composer) && !opt.key?(:with_attr)
               raise ArgumentError if opt.key?(:with_attr) && opt[:with_attr].size != original_method.arity
+              if !opt.key?(:with_attr)
+                opt[:with_attr] = original_method.parameters.map { |p| p[1] }
+              end
             end
 
             singleton_class.send(:define_method, symbol) do |*args|

--- a/test/active_record/method_cache_test.rb
+++ b/test/active_record/method_cache_test.rb
@@ -220,7 +220,7 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
     end
   end
 
-  def test_method_cache_class_method_with_expire_only
+  def test_method_cache_class_method_with_invalidate_only
     User.find_by_name_5("alice")
     assert_queries do
       User.find_by_name_5("alice")
@@ -347,7 +347,7 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
     assert_equal got.email, "alice@example.org"
   end
 
-  def test_method_cache_instance_method_with_expire_only
+  def test_method_cache_instance_method_with_invalidate_only
     alice = User.find_alice
     alice.find_myself_3
     assert_queries do

--- a/test/active_record/method_cache_test.rb
+++ b/test/active_record/method_cache_test.rb
@@ -59,6 +59,23 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
     end
   end
 
+  def test_method_cache_class_method_with_negative
+    User.find_frank
+    no_connection do
+      frank = User.find_frank
+      assert_nil frank
+    end
+  end
+
+  def test_method_cache_class_method_with_negative_and_value
+    User.find_negative_alice
+    no_connection do
+      alice = User.find_negative_alice
+      assert_not_nil alice
+      assert_equal alice.name, "alice"
+    end
+  end
+
   def test_method_cache_instance_method
     alice = User.find_alice
     alice.find_carol
@@ -66,6 +83,27 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
       b = alice.find_carol
       assert_not_nil b
       assert_equal b.name, "carol"
+    end
+  end
+
+  def test_method_cache_instance_method_with_negative
+    alice = User.find_alice
+    alice.find_eve
+
+    no_connection do
+      f = alice.find_eve
+      assert_nil f
+    end
+  end
+
+  def test_method_cache_instance_method_with_negative_and_value
+    alice = User.find_alice
+    alice.find_negative_carol
+
+    no_connection do
+      carol = alice.find_negative_carol
+      assert_not_nil carol
+      assert_equal carol.name, "carol"
     end
   end
 

--- a/test/active_record/method_cache_test.rb
+++ b/test/active_record/method_cache_test.rb
@@ -9,9 +9,21 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
   end
 
   def test_method_cache_key
-    assert_equal User.method_cache_key("alice"), "slc/user/mc/3/alice"
-    assert_equal User.method_cache_key("alice", *[]), "slc/user/mc/3/alice"
-    assert_equal User.method_cache_key("alice", "bob"), "slc/user/mc/3/alice/bob"
+    assert_equal User.method_cache_key("alice"), ["slc/user/mc/3/alice"]
+    assert_equal User.method_cache_key("alice", *[]), ["slc/user/mc/3/alice"]
+    assert_equal User.method_cache_key("alice", "bob"), ["slc/user/mc/3/alice/bob"]
+    assert_equal User.method_cache_key("alice", distributed: true), [
+      "slc/user/mc/3/0/alice",
+      "slc/user/mc/3/1/alice",
+      "slc/user/mc/3/2/alice",
+      "slc/user/mc/3/3/alice",
+      "slc/user/mc/3/4/alice",
+      "slc/user/mc/3/5/alice",
+      "slc/user/mc/3/6/alice",
+      "slc/user/mc/3/7/alice",
+      "slc/user/mc/3/8/alice",
+      "slc/user/mc/3/9/alice",
+    ]
   end
 
   def test_method_cache_class_method
@@ -73,6 +85,14 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
       alice = User.find_negative_alice
       assert_not_nil alice
       assert_equal alice.name, "alice"
+    end
+  end
+
+  def test_method_cache_class_method_with_distributed
+    User.get_all
+    User.method_cache_key("get_all", distributed: true).each do |key|
+      v = SecondLevelCache.cache_store.read(key)
+      assert_not_nil v
     end
   end
 

--- a/test/active_record/method_cache_test.rb
+++ b/test/active_record/method_cache_test.rb
@@ -220,6 +220,13 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
     end
   end
 
+  def test_method_cache_class_method_with_expire_only
+    User.find_by_name_5("alice")
+    assert_queries do
+      User.find_by_name_5("alice")
+    end
+  end
+
   def test_method_cache_instance_method
     alice = User.find_alice
     alice.find_carol
@@ -319,7 +326,7 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
   def test_method_cache_instance_method_with_attr_and_expires
     alice = User.find_alice
     alice.find_myself_2
-    no_connection do
+    assert_no_queries do
       alice.find_myself_2
     end
 
@@ -338,5 +345,13 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
 
     got = obj.find_myself
     assert_equal got.email, "alice@example.org"
+  end
+
+  def test_method_cache_instance_method_with_expire_only
+    alice = User.find_alice
+    alice.find_myself_3
+    assert_queries do
+      alice.find_myself_3
+    end
   end
 end

--- a/test/active_record/method_cache_test.rb
+++ b/test/active_record/method_cache_test.rb
@@ -1,0 +1,73 @@
+require 'active_record/test_helper'
+
+class SecondLevelCache::MethodCacheTest < Test::Unit::TestCase
+  def setup
+    @user = User.create :name => "alice", :email => "alice@example.com"
+    @bob = User.create :name => "bob", :email => "bob@example.com"
+    @carol = User.create :name => "carol", :email => "carol@example.com"
+  end
+
+  def test_method_cache_key
+    assert_equal User.method_cache_key("alice"), "slc/user/mc/3/alice"
+    assert_equal User.method_cache_key("alice", *[]), "slc/user/mc/3/alice"
+  end
+
+  def test_method_cache_class_method
+    User.find_alice
+    no_connection do
+      alice = User.find_alice
+      assert_not_nil alice
+      assert_equal alice.name, "alice"
+    end
+  end
+
+  def test_method_cache_class_method_with_args
+    User.find_by_name("alice")
+    User.find_by_name("bob")
+    no_connection do
+      alice = User.find_by_name("alice")
+      bob = User.find_by_name("bob")
+
+      assert_not_nil alice
+      assert_equal alice.name, "alice"
+      assert_not_nil bob
+      assert_equal bob.name, "bob"
+    end
+  end
+
+  def test_method_cache_class_method_with_singleton_class
+    User.find_bob
+    no_connection do
+      bob = User.find_bob
+      assert_not_nil bob
+      assert_equal bob.name, "bob"
+    end
+  end
+
+  def test_method_cache_instance_method
+    alice = User.find_alice
+    alice.find_carol
+    no_connection do
+      b = alice.find_carol
+      assert_not_nil b
+      assert_equal b.name, "carol"
+    end
+  end
+
+  def test_method_cache_instance_method_with_attr
+    alice = User.find_alice
+    alice.find_myself
+    bob = User.find_bob
+    bob.find_myself
+
+    no_connection do
+      alice_myself = alice.find_myself
+      bob_myself = bob.find_myself
+
+      assert_not_nil alice_myself
+      assert_equal alice_myself.name, "alice"
+      assert_not_nil bob_myself
+      assert_equal bob_myself.name, "bob"
+    end
+  end
+end

--- a/test/active_record/method_cache_test.rb
+++ b/test/active_record/method_cache_test.rb
@@ -75,6 +75,22 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
     end
   end
 
+  def test_method_cache_class_method_without_attr
+    alice = User.find_by_name_3("alice")
+    assert_no_queries do
+      User.find_by_name_3("alice")
+    end
+
+    alice.email = "alice@example.org"
+    alice.save
+
+    assert_queries do
+      User.find_by_name_3("alice")
+    end
+
+    assert_equal User.find_by_name_3("alice").email, "alice@example.org"
+  end
+
   def test_method_cache_class_method_with_prefix
     User.get_all_2
     User.method_cache_keys("get_all_2", prefix: "2").each do |key|

--- a/test/active_record/method_cache_test.rb
+++ b/test/active_record/method_cache_test.rb
@@ -99,4 +99,18 @@ class SecondLevelCache::MethodCacheTest < ActiveSupport::TestCase
       alice.find_ellen
     end
   end
+
+  def test_method_cache_instance_method_with_attr_and_expires
+    alice = User.find_alice
+    alice.find_myself_2
+    no_connection do
+      alice.find_myself_2
+    end
+
+    sleep 1.5
+
+    assert_queries do
+      alice.find_myself_2
+    end
+  end
 end

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -21,6 +21,16 @@ class User < ActiveRecord::Base
   end
   method_cache :find_alice
 
+  def self.find_negative_alice
+    User.where(name: "alice").first
+  end
+  method_cache :find_negative_alice, negative: true
+
+  def self.find_frank
+    User.where(name: "frank").first
+  end
+  method_cache :find_frank, negative: true
+
   def self.find_by_name(name)
     User.where(name: name).first
   end
@@ -36,10 +46,20 @@ class User < ActiveRecord::Base
   end
   method_cache :find_carol
 
+  def find_negative_carol
+    User.where(name: "carol").first
+  end
+  method_cache :find_negative_carol, negative: true
+
   def find_ellen
     User.where(name: "ellen").first
   end
   method_cache :find_ellen, expires_in: 1
+
+  def find_eve
+    User.where(name: "eve").first
+  end
+  method_cache :find_eve, with_attr: %i{name}, negative: true
 
   def find_myself
     User.where(name: self.name).first

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -79,7 +79,7 @@ class User < ActiveRecord::Base
   def self.find_by_name_5(name)
     User.where(name: name).first
   end
-  method_cache :find_by_name_5, expire_only: true
+  method_cache :find_by_name_5, invalidate_only: true
 
   def self.find_by_email(email)
     User.where(email: email).first
@@ -129,7 +129,7 @@ class User < ActiveRecord::Base
   def find_myself_3
     User.where(name: self.name).first
   end
-  method_cache :find_myself_3, expire_only: true
+  method_cache :find_myself_3, invalidate_only: true
 
   class << self
     def find_bob

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -26,6 +26,11 @@ class User < ActiveRecord::Base
   end
   method_cache :get_all_2, prefix: "2"
 
+  def self.get_all_3
+    User.all
+  end
+  method_cache :get_all_3, composer: lambda { "get" }
+
   def self.find_alice
     User.where(name: "alice").first
   end
@@ -46,6 +51,11 @@ class User < ActiveRecord::Base
   end
   method_cache :find_by_name, with_attr: %i{name}
 
+  def self.find_by_name_2(name)
+    User.where(name: name).first
+  end
+  method_cache :find_by_name_2, with_attr: %i{name}, composer: lambda { "by_name_2" }
+
   def self.find_by_email(email)
     User.where(email: email).first
   end
@@ -65,6 +75,11 @@ class User < ActiveRecord::Base
     User.where(name: "ellen").first
   end
   method_cache :find_ellen, expires_in: 1
+
+  def find_ellen_2
+    User.where(name: "ellen").first
+  end
+  method_cache :find_ellen_2, composer: lambda { "ellen" }
 
   def find_eve
     User.where(name: "eve").first

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -21,6 +21,11 @@ class User < ActiveRecord::Base
   end
   method_cache :get_all, distributed: true
 
+  def self.get_all_2
+    User.all
+  end
+  method_cache :get_all_2, prefix: "2"
+
   def self.find_alice
     User.where(name: "alice").first
   end
@@ -65,6 +70,11 @@ class User < ActiveRecord::Base
     User.where(name: "eve").first
   end
   method_cache :find_eve, with_attr: %i{name}, negative: true
+
+  def find_justin
+    User.where(name: "justin").first
+  end
+  method_cache :find_justin, prefix: "2"
 
   def find_myself
     User.where(name: self.name).first

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -15,4 +15,31 @@ class User < ActiveRecord::Base
 
   has_many :books
   has_many :images, :as => :imagable
+
+  def self.find_alice
+    User.where(name: "alice").first
+  end
+  method_cache :find_alice
+
+  def self.find_by_name(name)
+    User.where(name: name).first
+  end
+  method_cache :find_by_name
+
+  def find_carol
+    User.where(name: "carol").first
+  end
+  method_cache :find_carol
+
+  def find_myself
+    User.where(name: self.name).first
+  end
+  method_cache :find_myself, with_attr: %i{name}
+
+  class << self
+    def find_bob
+      User.where(name: "bob").first
+    end
+    User.method_cache :find_bob
+  end
 end

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -39,12 +39,12 @@ class User < ActiveRecord::Base
   def self.find_by_name(name)
     User.where(name: name).first
   end
-  method_cache :find_by_name
+  method_cache :find_by_name, with_attr: %i{name}
 
   def self.find_by_email(email)
     User.where(email: email).first
   end
-  method_cache :find_by_email, expires_in: 1
+  method_cache :find_by_email, expires_in: 1, with_attr: %i{email}
 
   def find_carol
     User.where(name: "carol").first

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -16,6 +16,11 @@ class User < ActiveRecord::Base
   has_many :books
   has_many :images, :as => :imagable
 
+  def self.get_all
+    User.all
+  end
+  method_cache :get_all, distributed: true
+
   def self.find_alice
     User.where(name: "alice").first
   end

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -46,6 +46,11 @@ class User < ActiveRecord::Base
   end
   method_cache :find_myself, with_attr: %i{name}
 
+  def find_myself_2
+    User.where(name: self.name).first
+  end
+  method_cache :find_myself_2, with_attr: %i{name}, expires_in: 1
+
   class << self
     def find_bob
       User.where(name: "bob").first

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -56,6 +56,11 @@ class User < ActiveRecord::Base
   end
   method_cache :find_by_name_2, with_attr: %i{name}, composer: lambda { "by_name_2" }
 
+  def self.find_by_name_3(name)
+    User.where(name: name).first
+  end
+  method_cache :find_by_name_3
+
   def self.find_by_email(email)
     User.where(email: email).first
   end

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -46,6 +46,16 @@ class User < ActiveRecord::Base
   end
   method_cache :find_frank, negative: true
 
+  def self.find_dave
+    User.where(name: "dave").first
+  end
+  method_cache :find_dave, record_marshal: true
+
+  def self.find_daves
+    User.where(name: "dave").to_a
+  end
+  method_cache :find_daves, record_marshal: true
+
   def self.find_by_name(name)
     User.where(name: name).first
   end

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -71,6 +71,11 @@ class User < ActiveRecord::Base
   end
   method_cache :find_by_name_3
 
+  def self.find_by_name_4(name)
+    User.where(name: name).first
+  end
+  method_cache :find_by_name_4, invalidate_old_attr: true
+
   def self.find_by_email(email)
     User.where(email: email).first
   end

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -26,10 +26,20 @@ class User < ActiveRecord::Base
   end
   method_cache :find_by_name
 
+  def self.find_by_email(email)
+    User.where(email: email).first
+  end
+  method_cache :find_by_email, expires_in: 1
+
   def find_carol
     User.where(name: "carol").first
   end
   method_cache :find_carol
+
+  def find_ellen
+    User.where(name: "ellen").first
+  end
+  method_cache :find_ellen, expires_in: 1
 
   def find_myself
     User.where(name: self.name).first

--- a/test/active_record/model/user.rb
+++ b/test/active_record/model/user.rb
@@ -76,6 +76,11 @@ class User < ActiveRecord::Base
   end
   method_cache :find_by_name_4, invalidate_old_attr: true
 
+  def self.find_by_name_5(name)
+    User.where(name: name).first
+  end
+  method_cache :find_by_name_5, expire_only: true
+
   def self.find_by_email(email)
     User.where(email: email).first
   end
@@ -120,6 +125,11 @@ class User < ActiveRecord::Base
     User.where(name: self.name).first
   end
   method_cache :find_myself_2, with_attr: %i{name}, expires_in: 1
+
+  def find_myself_3
+    User.where(name: self.name).first
+  end
+  method_cache :find_myself_3, expire_only: true
 
   class << self
     def find_bob


### PR DESCRIPTION
メソッドの結果をまるごとキャッシュするオプションを新たに提供します

## SYNOPSIS

```ruby
class User < ActiveRecord::Base
  acts_as_cached(version: 10, expires_in: 1.week)

  def self.get_all
    User.all
  end
  method_cache :get_all, distributed: true

  def self.get_all_2
    User.all
  end
  method_cache :get_all_2, prefix: "2" # キャッシュのキーに任意の値を加えることができる。同一のメソッドのままキャッシュのキーを切り替えたい時に利用できる。

  def self.get_all_3
    User.all
  end
  method_cache :get_all_3, composer: lambda { "get_all" } # キャッシュキー作成時に毎回評価されるメソッドを渡すこともできる。返り値がそのままキーの一部になる。

  def self.find_alice
    User.where(name: "alice").first
  end
  method_cache :find_alice # 特異メソッドを指定する場合が一番シンプル

  def self.find_by_name(name)
    User.where(name: name).first
  end
  method_cache :find_by_name, with_attr: %i{name}
  # 特異メソッドが引数を持っていた場合は特に指定することなくそれをキーに加える。
  # ただしexpire時にインスタンスから値を取る必要があるので対応するアトリビュートを指定する必要がある。
  # with_attr は引数の名前とアトリビュート名が一致する場合は省略できる。この場合、Userにnameというメソッドが存在するのであれば省略可。

  def self.find_by_name_2(name)
    User.where(name: name).first
  end
  method_cache :find_by_name_2, invalidate_old_attr: true
  # キャッシュのキーの値が変更される可能性がある場合は古い値でのキャッシュも消しておかないと更新されないキャッシュができてしまう。
  # invalidate_old_attrを指定するとwith_attrに指定されたアトリビュートの古い値もキーとして消す（after_saveのフックの中で_wasを呼び出す）
  # この場合もwith_attrは省略可能。

  def self.find_by_name_3(name)
    User.where(name: name).first
  end
  method_cache :find_by_name_3, invalidate_only: true # キャッシュはせずdeleteだけ動作するようになる

  def self.find_frank
    User.where(name: "frank").first
  end
  method_cache :find_frank, negative: true # ネガティブキャッシュをしたい場合はオプションを指定する。この場合返り値を配列にしたりする必要はない。

  def self.find_dave
    User.where(name: "dave").first
  end
  method_cache :find_dave, record_marshal: true # シリアライズにRecordMarshalを使用するオプション。空間効率が良くなる。ただしnilはキャッシュできない。

  def self.find_by_email(email)
    User.where(email: email).first
  end
  method_cache :find_by_email, expires_in: 1.day, with_attr: %i{email} # expires_inオプションを指定することで一部だけexpireを変更することができる（指定しない場合はクラスごとのデフォルトが、さらにそれも指定されてない場合はグローバルでのデフォルトが利用される）

  def find_carol
    User.where(name: "carol").first
  end
  method_cache :find_carol # インスタンスメソッドの場合もシンプル

  def find_myself
    User.where(name: self.name).first
  end
  method_cache :find_myself, with_attr: %i{name} # インスタンスメソッドの中でアトリビュートを使っている場合は引数に指定する（残念ながらmethod_cacheはメソッドの中の実装まで調べない）

  class << self
    def find_bob
      User.where(name: "bob").first
    end
    User.method_cache :find_bob # 特異クラスの中で使う場合は、残念ながらクラス名の指定が必要。クラスメソッドを特異クラスの中で定義して、外側でmethod_cacheを呼び出すのは問題ない
  end
end
```

## CAUTION

クラスメソッドとインスタンスメソッドに同名のものがある場合、クラスメソッドが優先される

```ruby
class User < ActiveRecord::Base
  acts_as_cached

  def self.find_frank
    User.where(name: "frank").first
  end
  method_cache :find_frank # これは期待通り動作する

  def find_frank
    User.where(name: "frank").first
  end
  method_cache :find_frank, with_attr: %i{name} # これは期待通り"全く"動作しない
end
```

## TODO

- [x] `expires_in` オプション
- [x] `negative_cache` オプション
- [x] `distributed` オプション
- [x] `prefix` オプション
- [x] expireさせる
- [x] after_saveに対応させる
  - after_saveの時はwasが使われる
- [x] `RecordMarshal` を使うオプション
- [x] attrオプションの省略記法
- [x] `invalidate_only` オプション