### PR TITLE
Global disable second_level_cache

### DIFF
--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -8,17 +8,17 @@ module SecondLevelCache
     block_given? ? yield(Config) : Config
   end
 
-  @@second_level_cache_global_enabled = true
+  @@enabled = true
 
-  def self.without_second_level_cache
-    old, @@second_level_cache_global_enabled = @@second_level_cache_global_enabled, false
+  def self.without_cache
+    old, @@enabled = @@enabled, false
     yield if block_given?
   ensure
-    @@second_level_cache_global_enabled = old
+    @@enabled = old
   end
 
   def self.enabled?
-    @@second_level_cache_global_enabled
+    @@enabled
   end
 
   class << self

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -8,6 +8,19 @@ module SecondLevelCache
     block_given? ? yield(Config) : Config
   end
 
+  @@second_level_cache_global_enabled = true
+
+  def self.without_second_level_cache
+    old, @@second_level_cache_global_enabled = @second_level_cache_global_enabled, false
+    yield if block_given?
+  ensure
+    @@second_level_cache_global_enabled = old
+  end
+
+  def self.enabled?
+    @@second_level_cache_global_enabled
+  end
+
   class << self
     delegate :logger, :cache_store, :cache_key_prefix, :to => Config
   end
@@ -37,7 +50,7 @@ module SecondLevelCache
       end
 
       def second_level_cache_enabled?
-        !!@second_level_cache_enabled
+        !!@second_level_cache_enabled && SecondLevelCache.enabled?
       end
 
       def second_level_cache_expire_only?

--- a/lib/second_level_cache.rb
+++ b/lib/second_level_cache.rb
@@ -11,7 +11,7 @@ module SecondLevelCache
   @@second_level_cache_global_enabled = true
 
   def self.without_second_level_cache
-    old, @@second_level_cache_global_enabled = @second_level_cache_global_enabled, false
+    old, @@second_level_cache_global_enabled = @@second_level_cache_global_enabled, false
     yield if block_given?
   ensure
     @@second_level_cache_global_enabled = old

--- a/lib/second_level_cache/active_record/fetch_by_index.rb
+++ b/lib/second_level_cache/active_record/fetch_by_index.rb
@@ -2,7 +2,7 @@ module SecondLevelCache
   module ActiveRecord
     module FetchByIndex
       def fetch_by_index(**argv)
-        raise ArgumentError unless self.second_level_cache_enabled?
+        return self.where(**argv).to_a unless self.second_level_cache_enabled?
         raise ArgumentError if self.second_level_cache_expire_only?
         raise ArgumentError unless self.second_level_cache_options[:cache_indexes].include?(argv.keys.sort)
         ids = SecondLevelCache.cache_store.read(cache_index_key(argv))

--- a/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
+++ b/lib/second_level_cache/active_record/fetch_by_uniq_key.rb
@@ -3,7 +3,7 @@ module SecondLevelCache
   module ActiveRecord
     module FetchByUniqKey
       def fetch_by_uniq_keys(where_values)
-        raise ArgumentError unless self.second_level_cache_enabled?
+        return self.where(where_values).first unless self.second_level_cache_enabled?
         raise ArgumentError if self.second_level_cache_expire_only?
 
         cache_key = cache_uniq_key(where_values)

--- a/test/active_record/fetch_by_index_test.rb
+++ b/test/active_record/fetch_by_index_test.rb
@@ -1,6 +1,6 @@
 require 'active_record/test_helper'
 
-class ActiveRecord::FetchByIndexTest < Test::Unit::TestCase
+class ActiveRecord::FetchByIndexTest < ActiveSupport::TestCase
   def setup
     @user = User.create :name => "alice", :email => "alice@example.com"
     @review  = Review.create :user_id => @user.id, :title => "title 1", :body => "body 1", :visible => true
@@ -21,6 +21,22 @@ class ActiveRecord::FetchByIndexTest < Test::Unit::TestCase
     @review2.write_second_level_cache
     no_connection do
       reviews = Review.fetch_by_index(user_id: @user.id)
+      assert_equal reviews.size, 2
+      assert_equal reviews[0], @review
+      assert_equal reviews[1], @review2
+    end
+  end
+
+  def test_fetch_by_index_with_cache_disabled
+    SecondLevelCache.cache_store.clear
+    SecondLevelCache.cache_store.write(Review.cache_index_key(user_id: @user.id), [@review.id, @review2.id])
+    @review.write_second_level_cache
+    @review2.write_second_level_cache
+    assert_sql(/SELECT\s+"reviews".* FROM "reviews"\s+WHERE "reviews"."user_id" = \d/) do
+      reviews = SecondLevelCache.without_cache do
+        Review.fetch_by_index(user_id: @user.id)
+      end
+
       assert_equal reviews.size, 2
       assert_equal reviews[0], @review
       assert_equal reviews[1], @review2

--- a/test/active_record/fetch_by_uniq_key_test.rb
+++ b/test/active_record/fetch_by_uniq_key_test.rb
@@ -46,9 +46,17 @@ class FetchByUinqKeyTest < ActiveSupport::TestCase
     assert_equal user, @user
   end
 
-  def test_raise_error_if_not_using_slc
-    assert_raises(ArgumentError) do
-      Group.fetch_by_uniq_keys(user_id: 1)
+  def test_read_from_db_if_not_using_slc
+    group = Group.fetch_by_uniq_keys(user_id: 1)
+    assert_equal group, nil
+  end
+
+  def test_read_from_db_if_temp_disable_slc
+    Post.fetch_by_uniq_keys(:topic_id => 2, :slug => "foobar")
+    assert_sql(/SELECT\s+"posts".* FROM "posts"\s+WHERE "posts"."topic_id" = 2 AND "posts"."slug" = 'foobar' LIMIT 1/) do
+      SecondLevelCache.without_cache do
+        Post.fetch_by_uniq_keys(:topic_id => 2, :slug => "foobar")
+      end
     end
   end
 end

--- a/test/active_record/finder_methods_test.rb
+++ b/test/active_record/finder_methods_test.rb
@@ -41,4 +41,14 @@ class ActiveRecord::FinderMethodsTest < Test::Unit::TestCase
     end
     assert_not_equal @user.name, @from_db.name
   end
+
+  def test_without_second_level_cache_globally
+    @user.name = "NewName"
+    @user.write_second_level_cache
+    SecondLevelCache.without_cache do
+      @from_db = User.find(@user.id)
+    end
+    @from_cache = User.find(@user.id)
+    assert_not_equal @from_cache.name, @from_db.name
+  end
 end


### PR DESCRIPTION
Global switch in case cache data is not reliable and we need some transparent select from DB.