### PR TITLE
serializerをdate columnに対応させる

### DIFF
--- a/lib/second_level_cache/serializer.rb
+++ b/lib/second_level_cache/serializer.rb
@@ -44,6 +44,8 @@ module SecondLevelCache
           if types[key].type == :datetime && value.present?
             sec, min, hour, day, month, year = value.to_a
             obj[key] = [year, month, day, hour, min, sec, value.utc_offset]
+          elsif types[key].type == :date && value.present?
+            obj[key] = value.to_s
           else
             obj[key] = value
           end
@@ -69,6 +71,8 @@ module SecondLevelCache
           if types[key].type == :datetime && value.present?
             year, month, day, hour, min, sec, utc_offset = value
             obj[key] = Time.new(year, month, day, hour, min, sec, utc_offset)
+          elsif types[key].type == :date && value.present?
+            obj[key] = Date.parse(value)
           end
         end
         obj

--- a/test/active_record/model/review.rb
+++ b/test/active_record/model/review.rb
@@ -5,6 +5,7 @@ ActiveRecord::Base.connection.create_table(:reviews, :force => true) do |t|
   t.string  :title
   t.text    :body
   t.boolean :visible
+  t.date    :visible_at
   t.timestamps
 end
 ActiveRecord::Base.connection.add_index(:reviews, %i{user_id book_id})

--- a/test/record_marshal_test.rb
+++ b/test/record_marshal_test.rb
@@ -5,7 +5,7 @@ class RecordMarshalTest < Test::Unit::TestCase
   def setup
     @user = User.create :name => 'csdn', :email => 'test@csdn.com'
     @book = Book.create :title => "book 1", :body => "body 1", :user_id => @user.id
-    @review = Review.create :user_id => @user.id, :book_id => @book.id, :title => "Most insane car ever!", :body => "Ferrari F12 is a most insane ever!", :visible => false
+    @review = Review.create :user_id => @user.id, :book_id => @book.id, :title => "Most insane car ever!", :body => "Ferrari F12 is a most insane ever!", :visible => false, :visible_at => Time.now.to_date
   end
 
   def test_should_dump_active_record_object
@@ -21,12 +21,14 @@ class RecordMarshalTest < Test::Unit::TestCase
     assert_equal %i{year month day hour min sec utc_offset}.map {|i| @review.updated_at.send(i)}, loaded[6]
     assert_equal @review.user_id, loaded[7]
     assert_equal @review.visible, loaded[8]
+    assert_equal @review.visible_at.to_s, loaded[9]
   end
-
 
   def test_should_load_active_record_object
     @user.write_second_level_cache
+    @review.write_second_level_cache
     assert_equal @user, User.read_second_level_cache(@user.id)
+    assert_equal @review, Review.read_second_level_cache(@review.id)
   end
 
 


### PR DESCRIPTION
date columnを含むAR objectをSLCでcache、もしくはds_cacheでuse_record_marshal (https://github.com/monsterstrike/server/blob/master/lib/ds_cache.rb#L233) するときに、 `RecordMarshal.dump` が呼ばれるが、 `MessagePack.dump` がdate対応していないので、to_sしてからdumpするようにした。

ついでに、 `test_should_load_active_record_object` のテストを追加した。