### PR TITLE
Call reload in without block

### DIFF
--- a/lib/second_level_cache/active_record/persistence.rb
+++ b/lib/second_level_cache/active_record/persistence.rb
@@ -17,7 +17,9 @@ module SecondLevelCache
       end
 
       def reload_with_second_level_cache(options = nil)
-        reload_without_second_level_cache(options).tap{expire_second_level_cache}
+        self.class.without_second_level_cache do
+          reload_without_second_level_cache(options)
+        end.tap{expire_second_level_cache}
       end
 
       def touch_with_second_level_cache(name = nil)


### PR DESCRIPTION
Working with other gems, sometimes `reload` is overwritten to call `find` instead. In which case, things fall back to second_level_cache, cause `reload_without_second_level_cache` actually to reload **WITH** second_level_cache. That is, reading from cache instead of db while reloading from db is expected.