### PR TITLE
「WIP」Do record marshal serialize fast

### DIFF
--- a/lib/second_level_cache/serializer.rb
+++ b/lib/second_level_cache/serializer.rb
@@ -44,6 +44,8 @@ module SecondLevelCache
           if types[key].type == :datetime && value.present?
             sec, min, hour, day, month, year = value.to_a
             obj[key] = [year, month, day, hour, min, sec, value.utc_offset]
+          elsif types[key].type == :date && value.present?
+            obj[key] = value.to_s
           else
             obj[key] = value
           end
@@ -69,6 +71,9 @@ module SecondLevelCache
           if types[key].type == :datetime && value.present?
             year, month, day, hour, min, sec, utc_offset = value
             obj[key] = Time.new(year, month, day, hour, min, sec, utc_offset)
+          elsif types[key].type == :date && value.present?
+            obj[key] = Date.parse(value)
+ 
           end
         end
         obj

--- a/lib/second_level_cache/serializer.rb
+++ b/lib/second_level_cache/serializer.rb
@@ -39,8 +39,8 @@ module SecondLevelCache
       #end
 
       def dump(record)
-        types = record.class.columns_hash
-        obj = record.attributes.each_with_object({}) do |(key, value), obj|
+        types = cached_columns_hash(record.class)
+        obj = record.instance_variable_get(:@attributes).each_with_object({}) do |(key, value), obj|
           if types[key].type == :datetime && value.present?
             sec, min, hour, day, month, year = value.to_a
             obj[key] = [year, month, day, hour, min, sec, value.utc_offset]
@@ -77,7 +77,13 @@ module SecondLevelCache
       protected
 
       def sorted_columns(klass)
-        klass.columns.map(&:name).sort
+        @sorted_columns ||= {}
+        @sorted_columns[klass] ||= klass.columns.map(&:name).sort
+      end
+
+      def cached_columns_hash(klass)
+        @cached_columns_hash ||= {}
+        @cached_columns_hash[klass] ||= klass.columns_hash
       end
     end
   end

--- a/lib/second_level_cache/serializer.rb
+++ b/lib/second_level_cache/serializer.rb
@@ -39,7 +39,7 @@ module SecondLevelCache
       #end
 
       def dump(record)
-        types = cached_columns_hash(record.class)
+        types = record.class.columns_hash
         obj = record.instance_variable_get(:@attributes).each_with_object({}) do |(key, value), obj|
           if types[key].type == :datetime && value.present?
             sec, min, hour, day, month, year = value.to_a
@@ -79,11 +79,6 @@ module SecondLevelCache
       def sorted_columns(klass)
         @sorted_columns ||= {}
         @sorted_columns[klass] ||= klass.columns.map(&:name).sort
-      end
-
-      def cached_columns_hash(klass)
-        @cached_columns_hash ||= {}
-        @cached_columns_hash[klass] ||= klass.columns_hash
       end
     end
   end


### PR DESCRIPTION
In order to do record marshal faster, we need to:

* cache column schema for later use
* read raw attributes instead of calling type_cast of each (This WILL cause some problems to deal with)